### PR TITLE
Add link to video from original implementation (MindCub3r README)

### DIFF
--- a/robots/MINDCUB3R/README.md
+++ b/robots/MINDCUB3R/README.md
@@ -1,5 +1,7 @@
 # MINDCUB3R
 
+A working fork of cavenel's original code ([original video](https://www.youtube.com/watch?v=HuKsfp19yF0)).
+
 ## Installation
 ### Installing kociemba
 The kociemba program produces a sequence of moves used to solve


### PR DESCRIPTION
I found an alternative implementation that might be worth documenting. It also sports a demo video to show off the ev3dev-powered robot.

Would be cool if you integrated that into your README.