### PR TITLE
Remove unnecessary entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 *.pyc
 *.swp
-robots/BALANC3R/ev3dev
-robots/EDUCATOR/ev3dev


### PR DESCRIPTION
Fixes problem with pull request #26. Will use .git/info/exclude from now on.