### PR TITLE
Mention apt-get update in README

### DIFF
--- a/robots/MINDCUB3R/README.md
+++ b/robots/MINDCUB3R/README.md
@@ -7,6 +7,7 @@ A working fork of cavenel's original code ([original video](https://www.youtube.
 The kociemba program produces a sequence of moves used to solve
 a 3x3x3 rubiks cube.
 ```
+$ sudo apt-get update
 $ sudo apt-get install build-essential libffi-dev
 $ cd ~/
 $ git clone https://github.com/dwalton76/kociemba.git


### PR DESCRIPTION
Without up-to-date package information `apt-get install build-essential` reports:
```
Package build-essential is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'build-essential' has no installation candidate
```
This PR adds the `apt-get update` command to the README to avoid this situation.